### PR TITLE
Add previous exception message

### DIFF
--- a/src/Spryker/Service/Opentelemetry/Instrumentation/Span/Span.php
+++ b/src/Spryker/Service/Opentelemetry/Instrumentation/Span/Span.php
@@ -260,6 +260,7 @@ class Span extends OtelSpan implements ReadWriteSpanInterface, SpanDataInterface
         $eventAttributesBuilder = $this->spanLimits->getEventAttributesFactory()->builder([
             'exception.type' => $exception::class,
             'exception.message' => $exception->getMessage(),
+            'exception.previous_message' => $exception->getPrevious()?->getMessage(),
             'exception.stacktrace' => StackTraceFormatter::format($exception),
         ]);
 


### PR DESCRIPTION
Important details are currently missing in the OpenTelemetry error data. For example, exception.message is "Unable to execute INSERT statement [<query>]", but it's not clear why it failed. The detailed error message (e.g. "General error: 1364 Field 'foobar' doesn't have a default value") can be found in the previous exception and needs to be included.
